### PR TITLE
Re-add prefix and add extra test to postfix

### DIFF
--- a/Source/AutopsyTable/Harvest.cs
+++ b/Source/AutopsyTable/Harvest.cs
@@ -11,34 +11,38 @@ namespace AutopsyTable;
 [HarmonyPatch(typeof(Corpse), "ButcherProducts")]
 public static class Harvest
 {
-    //public static bool Prefix(ref IEnumerable<Thing> __result, ref Corpse __instance, Pawn butcher)
-    //{
-    //    if (butcher.CurJob?.GetTarget(TargetIndex.A).Thing == null ||
-    //        butcher.CurJob.GetTarget(TargetIndex.A).Thing.def.defName != "TableAutopsy")
-    //    {
-    //        return true;
-    //    }
+    public static bool Prefix(ref IEnumerable<Thing> __result, ref Corpse __instance, Pawn butcher)
+    {
+        if (butcher.CurJob?.GetTarget(TargetIndex.A).Thing == null ||
+            butcher.CurJob.GetTarget(TargetIndex.A).Thing.def.defName != "TableAutopsy")
+        {
+            return true;
+        }
 
-    //    if (butcher.CurJob?.RecipeDef?.defName != "AutopsyHumanoid")
-    //    {
-    //        return true;
-    //    }
+        if (butcher.CurJob?.RecipeDef?.defName != "AutopsyHumanoid")
+        {
+            return true;
+        }
 
-    //    var table = butcher.CurJob.GetTarget(TargetIndex.A).Thing as Building_WorkTable;
-    //    __result = __instance.InnerPawn.DetachValuableItems(table, butcher).ToList();
-    //    if (__instance.InnerPawn.RaceProps.BloodDef != null)
-    //    {
-    //        FilthMaker.TryMakeFilth(butcher.Position, butcher.Map, __instance.InnerPawn.RaceProps.BloodDef,
-    //            __instance.InnerPawn.LabelIndefinite());
-    //    }
+        var table = butcher.CurJob.GetTarget(TargetIndex.A).Thing as Building_WorkTable;
+        __result = __instance.InnerPawn.DetachValuableItems(table, butcher).ToList();
+        if (__instance.InnerPawn.RaceProps.BloodDef != null)
+        {
+            FilthMaker.TryMakeFilth(butcher.Position, butcher.Map, __instance.InnerPawn.RaceProps.BloodDef,
+                __instance.InnerPawn.LabelIndefinite());
+        }
 
-    //    return false;
-    //}
+        return false;
+    }
 
     public static void Postfix(ref IEnumerable<Thing> __result, ref Corpse __instance, Pawn butcher)
     {
         if (butcher.CurJob?.GetTarget(TargetIndex.A).Thing == null ||
             butcher.CurJob.GetTarget(TargetIndex.A).Thing.def.defName != "TableAutopsy")
+        {
+            return;
+        }
+        if (butcher.CurJob?.RecipeDef?.defName == "AutopsyHumanoid")
         {
             return;
         }


### PR DESCRIPTION
Restore the prefix function to prevents the normal autopsy from doing a full butcher (by skipping the native method). Adding the inverse check to the postfix function prevents the double bionics without also producing unwanted meat/leather and mood maluses. 